### PR TITLE
Replaced isMaster with isPrimary

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ In the example below, the variable `options` is passed to the admiral. [Read the
 
 Here is an example of `index.js`:
 ```js
-const { isMaster } = require('cluster');
+const { isPrimary } = require('cluster');
 const { Fleet } = require('eris-fleet');
 const path = require('path');
 const { inspect } = require('util');
@@ -85,7 +85,7 @@ const options = {
 
 const Admiral = new Fleet(options);
 
-if (isMaster) {
+if (isPrimary) {
     // Code to only run for your master process
     Admiral.on('log', m => console.log(m));
     Admiral.on('debug', m => console.debug(m));


### PR DESCRIPTION
I replaced `isMaster` with `isPrimary`, because `isMaster` has been deprecated.